### PR TITLE
Fix compile errors for macOS 10.12

### DIFF
--- a/bench/cpp/bitreverse_tb.cpp
+++ b/bench/cpp/bitreverse_tb.cpp
@@ -76,14 +76,14 @@ void	tick(TSTCLASS *brev) {
 
 	brev->i_clk = 0;
 	brev->eval();
-	if (trace)	trace->dump((uint64_t)(10ul*m_tickcount-2));
+	if (trace)	trace->dump((vluint64_t)(10ul*m_tickcount-2));
 	brev->i_clk = 1;
 	brev->eval();
-	if (trace)	trace->dump((uint64_t)(10ul*m_tickcount));
+	if (trace)	trace->dump((vluint64_t)(10ul*m_tickcount));
 	brev->i_clk = 0;
 	brev->eval();
 	if (trace) {
-		trace->dump((uint64_t)(10ul*m_tickcount+5));
+		trace->dump((vluint64_t)(10ul*m_tickcount+5));
 		trace->flush();
 	}
 

--- a/bench/cpp/butterfly_tb.cpp
+++ b/bench/cpp/butterfly_tb.cpp
@@ -103,14 +103,14 @@ public:
 		m_lastaux = m_bfly->o_aux;
 		m_bfly->i_clk = 0;
 		m_bfly->eval();
-		if (m_trace) m_trace->dump((uint64_t)(10ul*m_tickcount-2));
+		if (m_trace) m_trace->dump((vluint64_t)(10ul*m_tickcount-2));
 		m_bfly->i_clk = 1;
 		m_bfly->eval();
-		if (m_trace) m_trace->dump((uint64_t)(10ul*m_tickcount));
+		if (m_trace) m_trace->dump((vluint64_t)(10ul*m_tickcount));
 		m_bfly->i_clk = 0;
 		m_bfly->eval();
 		if (m_trace) {
-			m_trace->dump((uint64_t)(10ul*m_tickcount+5));
+			m_trace->dump((vluint64_t)(10ul*m_tickcount+5));
 			m_trace->flush();
 		}
 

--- a/bench/cpp/fftstage_tb.cpp
+++ b/bench/cpp/fftstage_tb.cpp
@@ -135,14 +135,14 @@ assert(OWIDTH == IWIDTH+1);
 
 		m_ftstage->i_clk = 0;
 		m_ftstage->eval();
-		if (m_trace)	m_trace->dump((uint64_t)(10ul*m_tickcount-2));
+		if (m_trace)	m_trace->dump((vluint64_t)(10ul*m_tickcount-2));
 		m_ftstage->i_clk = 1;
 		m_ftstage->eval();
-		if (m_trace)	m_trace->dump((uint64_t)(10ul*m_tickcount));
+		if (m_trace)	m_trace->dump((vluint64_t)(10ul*m_tickcount));
 		m_ftstage->i_clk = 0;
 		m_ftstage->eval();
 		if (m_trace) {
-			m_trace->dump((uint64_t)(10ul*m_tickcount+5));
+			m_trace->dump((vluint64_t)(10ul*m_tickcount+5));
 			m_trace->flush();
 		}
 	}

--- a/bench/cpp/hwbfly_tb.cpp
+++ b/bench/cpp/hwbfly_tb.cpp
@@ -103,14 +103,14 @@ public:
 		m_lastaux = m_bfly->o_aux;
 		m_bfly->i_clk = 0;
 		m_bfly->eval();
-		if (m_trace) m_trace->dump((uint64_t)(10ul*m_tickcount-2));
+		if (m_trace) m_trace->dump((vluint64_t)(10ul*m_tickcount-2));
 		m_bfly->i_clk = 1;
 		m_bfly->eval();
-		if (m_trace) m_trace->dump((uint64_t)(10ul*m_tickcount));
+		if (m_trace) m_trace->dump((vluint64_t)(10ul*m_tickcount));
 		m_bfly->i_clk = 0;
 		m_bfly->eval();
 		if (m_trace) {
-			m_trace->dump((uint64_t)(10ul*m_tickcount+5));
+			m_trace->dump((vluint64_t)(10ul*m_tickcount+5));
 			m_trace->flush();
 		}
 

--- a/bench/cpp/laststage_tb.cpp
+++ b/bench/cpp/laststage_tb.cpp
@@ -97,14 +97,14 @@ public:
 
 		m_last->i_clk = 0;
 		m_last->eval();
-		if (m_trace) m_trace->dump((uint64_t)(10ul * m_tickcount - 2));
+		if (m_trace) m_trace->dump((vluint64_t)(10ul * m_tickcount - 2));
 		m_last->i_clk = 1;
 		m_last->eval();
-		if (m_trace) m_trace->dump((uint64_t)(10ul * m_tickcount));
+		if (m_trace) m_trace->dump((vluint64_t)(10ul * m_tickcount));
 		m_last->i_clk = 0;
 		m_last->eval();
 		if (m_trace) {
-			m_trace->dump((uint64_t)(10ul * m_tickcount + 5));
+			m_trace->dump((vluint64_t)(10ul * m_tickcount + 5));
 			m_trace->flush();
 		}
 		m_last->i_reset  = 0;

--- a/bench/cpp/mpy_tb.cpp
+++ b/bench/cpp/mpy_tb.cpp
@@ -103,14 +103,14 @@ public:
 
 		m_mpy->i_clk = 0;
 		m_mpy->eval();
-		if (m_trace)	m_trace->dump((uint64_t)(10ul*m_tickcount-2));
+		if (m_trace)	m_trace->dump((vluint64_t)(10ul*m_tickcount-2));
 		m_mpy->i_clk = 1;
 		m_mpy->eval();
-		if (m_trace)	m_trace->dump((uint64_t)(10ul*m_tickcount));
+		if (m_trace)	m_trace->dump((vluint64_t)(10ul*m_tickcount));
 		m_mpy->i_clk = 0;
 		m_mpy->eval();
 		if (m_trace)	{
-			m_trace->dump((uint64_t)(10ul*m_tickcount+5));
+			m_trace->dump((vluint64_t)(10ul*m_tickcount+5));
 			m_trace->flush();
 		}
 	}

--- a/bench/cpp/qtrstage_tb.cpp
+++ b/bench/cpp/qtrstage_tb.cpp
@@ -109,14 +109,14 @@ public:
 
 		m_qstage->i_clk = 0;
 		m_qstage->eval();
-		if (m_trace)	m_trace->dump((uint64_t)(10ul*m_tickcount-2));
+		if (m_trace)	m_trace->dump((vluint64_t)(10ul*m_tickcount-2));
 		m_qstage->i_clk = 1;
 		m_qstage->eval();
-		if (m_trace)	m_trace->dump((uint64_t)(10ul*m_tickcount));
+		if (m_trace)	m_trace->dump((vluint64_t)(10ul*m_tickcount));
 		m_qstage->i_clk = 0;
 		m_qstage->eval();
 		if (m_trace) {
-			m_trace->dump((uint64_t)(10ul*m_tickcount+5));
+			m_trace->dump((vluint64_t)(10ul*m_tickcount+5));
 			m_trace->flush();
 		}
 


### PR DESCRIPTION
On macOS Sierra, running 'make bench' gives compile errors in all of the
verilator testbenches, complaining about an ambiguous call to dump
(because there is no dump() defined for a uint64_t, or clang++ doesn't
define vluint64_t to be the same as uint64_t). This patch fixes those
compiler errors

Compiler error:

```
mpy_tb.cpp:113:13: error: call to member function 'dump' is ambiguous
                        m_trace->dump((uint64_t)(10ul*m_tickcount+5));
                        ~~~~~~~~~^~~~
/usr/local/Cellar/verilator/3.926/share/verilator/include/verilated_vcd_c.h:434:10: note: candidate function
    void dump (vluint64_t timeui) { m_sptrace.dump(timeui); }
         ^
/usr/local/Cellar/verilator/3.926/share/verilator/include/verilated_vcd_c.h:437:10: note: candidate function
    void dump (double timestamp) { dump(static_cast<vluint64_t>(timestamp)); }
         ^
/usr/local/Cellar/verilator/3.926/share/verilator/include/verilated_vcd_c.h:438:10: note: candidate function
    void dump (vluint32_t timestamp) { dump(static_cast<vluint64_t>(timestamp)); }
         ^
/usr/local/Cellar/verilator/3.926/share/verilator/include/verilated_vcd_c.h:439:10: note: candidate function
    void dump (int timestamp) { dump(static_cast<vluint64_t>(timestamp)); }
```

versions:
```
$ clang++ -v
    Apple LLVM version 9.0.0 (clang-900.0.38)
    Target: x86_64-apple-darwin16.7.0
    Thread model: posix

$ verilator --version
    Verilator 3.926 2018-08-22 rev UNKNOWN_REV
```